### PR TITLE
fixed bugs related to TChain, added check on trigger, added l1 trigger path

### DIFF
--- a/Analysis/Utilities.C
+++ b/Analysis/Utilities.C
@@ -1018,7 +1018,7 @@ void ntupleClass_MC::TriggerRequirements(Int_t ind, TH1D *hTripTriggerMatched){
     nMatches = 0;
     for(int h=0; h<Trigger_l1name->size(); h++) {
         l1Name = Trigger_l1name->at(h);
-        if(strcmp(l1Name, "L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4") == 0 || strcmp(l1Name, "L1_TripleMu_5_3_0_DoubleMu_5_3_OS_Mass_Max1p7") == 0) {
+        if(strcmp(l1Name, "L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4") == 0 || strcmp(l1Name, "L1_TripleMu_5SQ_3SQ_0_DoubleMu_5_3_SQ_OS_Mass_Max9") == 0 || strcmp(l1Name, "L1_TripleMu_5_3_0_DoubleMu_5_3_OS_Mass_Max17") == 0) {
             nMatches++;
             l1_ind = h;
         }

--- a/Analysis/ntupleClass_Control.C
+++ b/Analysis/ntupleClass_Control.C
@@ -107,7 +107,7 @@ void ntupleClass_Control::LoopControl(){
     for (Long64_t jentry=0; jentry<nentries; jentry++) {
         ntripl = 0; trInd = 0; int cutevt2[NCUTS] = {0};
         Long64_t ientry = fChain->LoadTree(jentry);
-        fChain->GetEntry(ientry);
+        fChain->GetTree()->GetEntry(ientry);
         hPileUp_BC->Fill(nPileUpInt);
         hNPrVert_BC->Fill(PVCollection_Size);
 
@@ -316,7 +316,7 @@ void ntupleClass_Control::LoopControl_Data(TString type, TString datasetName){
     for (Long64_t jentry=0; jentry<nentries; jentry++) {
         ntripl = 0; trInd = 0; int cutevt2[NCUTS] = {0};
         Long64_t ientry = fChain->LoadTree(jentry);
-        fChain->GetEntry(ientry);
+        fChain->GetTree()->GetEntry(ientry);
         hPileUp_BC->Fill(nPileUpInt);
         hNPrVert_BC->Fill(PVCollection_Size);
         //Loop over the TRIPLETS

--- a/Analysis/ntupleClass_Control.C
+++ b/Analysis/ntupleClass_Control.C
@@ -166,7 +166,6 @@ void ntupleClass_Control::LoopControl(){
             if(cutevt2[k] > 0) cutevt[k]++;
         }
         // Histo N. triplets passed for each event
-        cout<<"ntripl = "<<ntripl<<endl;
         hNtripl->Fill(ntripl);
         if(ntripl > 0) {
             cutevt[NCUTS-1]++; cut[NCUTS-1]++;
@@ -376,7 +375,6 @@ void ntupleClass_Control::LoopControl_Data(TString type, TString datasetName){
         }
         // Histo N. triplets passed for each event
         hNtripl->Fill(ntripl);
-        cout<<"ntripl = "<<ntripl<<endl;
         if(ntripl > 0) {
             cutevt[NCUTS-1]++; cut[NCUTS-1]++;
             ind = BestTripletFinder(triplIndex, ntripl);
@@ -387,16 +385,13 @@ void ntupleClass_Control::LoopControl_Data(TString type, TString datasetName){
 
             if(Triplet2_Mass->at(ind) >= 1.93 && Triplet2_Mass->at(ind) <= 2.01) {
                //plot sgn
-               cout<<"Sgn region, NCUTS-3 = "<<NCUTS-3<<endl;
                FillHistoStepByStep("data", ind, mu_Ind, mu, NCUTS-3, hPt, hPt_mu, hEta, hEta_mu, hPhi, hVx, hVy, hVz, hPt_Tr, hEta_Tr, hPt_tripl, hEta_tripl, hPhi_tripl, hMass_tripl, IdsummaryDaughter, IdsummaryMother, Idsummary2D);
             }
             else if(Triplet2_Mass->at(ind) >= 1.7 && Triplet2_Mass->at(ind) <= 1.8){
                //plot bkg
-               cout<<"Bkg region, NCUTS-2 = "<<NCUTS-2<<endl;
                FillHistoStepByStep("data", ind, mu_Ind, mu, NCUTS-2, hPt, hPt_mu, hEta, hEta_mu, hPhi, hVx, hVy, hVz, hPt_Tr, hEta_Tr, hPt_tripl, hEta_tripl, hPhi_tripl, hMass_tripl, IdsummaryDaughter, IdsummaryMother, Idsummary2D);
             }
             //plot totale
-            cout<<"Total region, NCUTS-1 = "<<NCUTS-1<<endl;
             FillHistoStepByStep("data", ind, mu_Ind, mu, NCUTS-1, hPt, hPt_mu, hEta, hEta_mu, hPhi, hVx, hVy, hVz, hPt_Tr, hEta_Tr, hPt_tripl, hEta_tripl, hPhi_tripl, hMass_tripl, IdsummaryDaughter, IdsummaryMother, Idsummary2D);
             FillHistoAC(ind, mu, hChi2Track, hNMatchedStat, hFlightDist, hFlightDist_Signif, hFlightDistvsP, hPtErrOverPt, hmassdi, dimu, hmassQuad, hmassQuad_Zero, hChi2VertexNorm, hSegmComp, hDeltaR, hTrIPSign);
             hPileUp_AC->Fill(nPileUpInt);

--- a/Analysis/ntupleClass_MC.C
+++ b/Analysis/ntupleClass_MC.C
@@ -153,7 +153,7 @@ void ntupleClass_MC::LoopMC_New(TString type, TString datasetName){
         if(jentry == 147384)	continue;
 	ntripl = 0, trInd = 0; int cutevt2[NCUTS] = {0};
         Long64_t ientry = fChain->LoadTree(jentry);
-        fChain->GetEntry(ientry);
+        fChain->GetTree()->GetEntry(ientry);
         //Check number of tracks in the primary vertex
         if(PV_NTracks > NMU){
             hPileUp_BC->Fill(nPileUpInt);


### PR DESCRIPTION
- Fixed bug in TChain reader for all loop (see https://root.cern.ch/root/roottalk/roottalk04/0901.html)
- Added "L1_TripleMu_5SQ_3SQ_0_DoubleMu_5_3_SQ_OS_Mass_Max9" l1 seed
- Implemented check on fired HLT and L1 in tau3mu analysis
- now the option "data_bkg" is used only to produce the TTree for the BDT training
- in tau3mu data analysis, cut 3 is only selecting triplet_invariant_mass in 1.62 - 2 GeV
- final plot in tau3mu data analysis are filled after checking isTrigger_forAna
- additional plots in tau3mu data analysis filled separately for l1Double and l1Triple

	modified:   Utilities.C
	modified:   ntupleClass_Control.C
	modified:   ntupleClass_MC.C
	modified:   ntupleClass_data.C